### PR TITLE
feat(Window Framework): global controlled window title bar

### DIFF
--- a/lib/src/core/route/route.dart
+++ b/lib/src/core/route/route.dart
@@ -63,6 +63,7 @@ final class AppRoute<Ret, Arg extends Object> extends AppRouteIface {
   @override
   Widget toWidget({Key? key, Arg? args}) {
     return VirtualWindowFrame(
+      showCaption: WindowFrameConfig.showCaption,
       child: page(key: key, args: args),
     );
   }
@@ -94,7 +95,10 @@ final class AppRouteArg<Ret, Arg extends Object> extends AppRouteIface {
 
     final route_ = route ??
         MaterialPageRoute<Ret>(
-          builder: (_) => VirtualWindowFrame(child: page(key: key, args: args)),
+          builder: (_) => VirtualWindowFrame(
+            showCaption: WindowFrameConfig.showCaption,
+            child: page(key: key, args: args),
+          ),
           settings: routeSettings,
         );
     return Navigator.push<Ret>(context, route_);
@@ -106,6 +110,7 @@ final class AppRouteArg<Ret, Arg extends Object> extends AppRouteIface {
       throw ArgumentError('args cannot be null');
     }
     return VirtualWindowFrame(
+      showCaption: WindowFrameConfig.showCaption,
       child: page(key: key, args: args),
     );
   }
@@ -136,7 +141,10 @@ final class AppRouteNoArg<Ret> extends AppRouteIface {
 
     final route_ = route ??
         MaterialPageRoute<Ret>(
-          builder: (_) => VirtualWindowFrame(child: page(key: key)),
+          builder: (_) => VirtualWindowFrame(
+            showCaption: WindowFrameConfig.showCaption,
+            child: page(key: key),
+          ),
           settings: routeSettings,
         );
     return Navigator.push<Ret>(context, route_);
@@ -145,6 +153,7 @@ final class AppRouteNoArg<Ret> extends AppRouteIface {
   @override
   Widget toWidget({Key? key}) {
     return VirtualWindowFrame(
+      showCaption: WindowFrameConfig.showCaption,
       child: page(key: key),
     );
   }

--- a/lib/src/view/widget/virtual_window_frame.dart
+++ b/lib/src/view/widget/virtual_window_frame.dart
@@ -2,24 +2,41 @@ import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart' as wm;
 
+abstract final class WindowFrameConfig {
+  static bool _showCaption = true;
+
+  static bool get showCaption => _showCaption && isDesktop;
+
+  static void setShowCaption(bool value) {
+    _showCaption = value;
+  }
+}
+
 class VirtualWindowFrame extends StatelessWidget {
   final Widget child;
 
   /// Title of the window.
   final String? title;
 
-  const VirtualWindowFrame({super.key, required this.child, this.title});
+  /// Whether to show the virtual window caption.
+  /// 
+  /// Only affects desktop platforms. When set to false, the virtual caption will be hidden,
+  /// which is useful when the native title bar is shown.
+  final bool showCaption;
+
+  const VirtualWindowFrame({super.key, required this.child, this.title, this.showCaption = true});
 
   @override
   Widget build(BuildContext context) {
     final content = switch (CustomAppBar.sysStatusBarHeight) {
       0.0 => child,
-      _ => Column(
+      _ when showCaption && WindowFrameConfig.showCaption => Column(
           children: [
             _WindowCaption(title: title),
             Expanded(child: child),
           ],
         ),
+      _ => child,
     };
     return wm.VirtualWindowFrame(child: content);
   }


### PR DESCRIPTION
Resolve lollipopkit/flutter_server_box/issues/956.

This commit needs to be used in conjunction with behavioral changes in ServerBox and is incompatible with the current processing logic. I will push new changes to ServerBox later and then link these two changes together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added window caption visibility controls accessible both globally and per-instance
  * Caption display behavior now configurable with defaults set to show captions
  * Enhanced window frame customization options on supported platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->