### PR TITLE
build: Replace discontinued `flutter_markdown` with maintained `flutter_markdown_plus`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -355,22 +355,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: transitive
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
-  flutter_markdown_latex:
+    version: "1.0.7"
+  flutter_markdown_plus_latex:
     dependency: transitive
     description:
-      name: flutter_markdown_latex
-      sha256: "839e76a84abb3632ffcebbd450cf93c7e9894af65622527d23f0084cee1bfd04"
+      name: flutter_markdown_plus_latex
+      sha256: "2e7698b291f0657ca445efab730bb25a8c5851037e882cb7bf47d16a5c218de7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.5"
   flutter_math_fork:
     dependency: "direct overridden"
     description:

--- a/lib/src/core/utils/markdown.dart
+++ b/lib/src/core/utils/markdown.dart
@@ -1,6 +1,6 @@
 import 'package:fl_lib/fl_lib.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:flutter_markdown_latex/flutter_markdown_latex.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_markdown_plus_latex/flutter_markdown_plus_latex.dart';
 import 'package:markdown/markdown.dart' as md;
 
 abstract final class MarkdownUtils {

--- a/lib/src/view/widget/markdown.dart
+++ b/lib/src/view/widget/markdown.dart
@@ -1,6 +1,6 @@
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 final class SimpleMarkdown extends StatelessWidget {
   final String data;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   flutter_highlight: ^0.7.0
   flutter_localizations:
     sdk: flutter
-  flutter_markdown: ^0.7.1
-  flutter_markdown_latex: ^0.3.1
+  flutter_markdown_plus: ^1.0.7
+  flutter_markdown_plus_latex: ^1.0.5
   flutter_secure_storage: ^9.2.4
   flutter_staggered_grid_view: ^0.7.0
   freezed_annotation: ^3.0.0


### PR DESCRIPTION
`flutter_markdown` is deprecated and as a direct dependency, this PR migrates it to `flutter_markdown_plus`, which is continually maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated markdown rendering dependencies to newer versions with improved stability and performance.
  * Enhanced LaTeX support for mathematical expressions in markdown content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->