### PR TITLE
fix(widget): Add a `key` attribute to ChoiceChipX to avoid repeated rendering issues

### DIFF
--- a/lib/src/view/widget/choice.dart
+++ b/lib/src/view/widget/choice.dart
@@ -34,6 +34,7 @@ final class ChoiceWidget<T> extends StatelessWidget {
             final item = items.elementAtOrNull(index);
             if (item == null) return UIs.placeholder;
             return ChoiceChipX<T>(
+              key: ValueKey(item),
               label: display?.call(item) ?? item.toString(),
               state: state,
               value: item,


### PR DESCRIPTION
Add a ValueKey to ensure the ChoiceChipX component can be correctly rebuilt when the item changes, thereby avoiding potential rendering issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and rendering reliability of choice selection items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->