### PR TITLE
refactor (theme colors): Use `Theme.of` to retrieve `primaryColor` instead of hard-coding it

### DIFF
--- a/lib/src/view/widget/loading.dart
+++ b/lib/src/view/widget/loading.dart
@@ -27,11 +27,15 @@ final class SizedLoading extends StatelessWidget {
   const SizedLoading(this.size, {this.padding = 7, this.valueColor, this.builder = linearBuilder, super.key});
 
   static Widget linearBuilder(BuildContext context, Animation<Color>? valueColor) {
-    return LinearProgressIndicator(valueColor: valueColor ?? AlwaysStoppedAnimation(UIs.primaryColor));
+    return LinearProgressIndicator(
+      valueColor: valueColor ?? AlwaysStoppedAnimation(Theme.of(context).colorScheme.primary),
+    );
   }
 
   static Widget circularBuilder(BuildContext context, Animation<Color>? valueColor) {
-    return CircularProgressIndicator(valueColor: valueColor ?? AlwaysStoppedAnimation(UIs.primaryColor));
+    return CircularProgressIndicator(
+      valueColor: valueColor ?? AlwaysStoppedAnimation(Theme.of(context).colorScheme.primary),
+    );
   }
 
   @override

--- a/lib/src/view/widget/markdown.dart
+++ b/lib/src/view/widget/markdown.dart
@@ -18,6 +18,7 @@ final class SimpleMarkdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
     return MarkdownBody(
       data: data,
       onTapLink: (text, href, title) async {
@@ -29,8 +30,8 @@ final class SimpleMarkdown extends StatelessWidget {
       },
       selectable: selectable,
       extensionSet: MarkdownUtils.extensionSet,
-      styleSheet: styleSheet?.copyWith(a: TextStyle(color: UIs.colorSeed)) ??
-          MarkdownStyleSheet(a: TextStyle(color: UIs.colorSeed)),
+      styleSheet:
+          styleSheet?.copyWith(a: TextStyle(color: primaryColor)) ?? MarkdownStyleSheet(a: TextStyle(color: primaryColor)),
     );
   }
 }

--- a/lib/src/view/widget/qr/qr.dart
+++ b/lib/src/view/widget/qr/qr.dart
@@ -25,6 +25,7 @@ final class QrView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
     final qrImg = QrImage(QrCode.fromData(
       data: data,
       errorCorrectLevel: QrErrorCorrectLevel.M,
@@ -33,7 +34,7 @@ final class QrView extends StatelessWidget {
       background: Colors.white,
       shape: PrettyQrSmoothSymbol(
         roundFactor: 1,
-        color: UIs.primaryColor,
+        color: primaryColor,
       ),
       image:
           centerImg != null ? PrettyQrDecorationImage(image: centerImg!) : null,
@@ -48,7 +49,7 @@ final class QrView extends StatelessWidget {
           Text(
             tip!,
             style: TextStyle(
-              color: UIs.primaryColor,
+              color: primaryColor,
               fontSize: 17,
               fontWeight: FontWeight.w500,
             ),

--- a/lib/src/view/widget/qr/qr.dart
+++ b/lib/src/view/widget/qr/qr.dart
@@ -25,7 +25,7 @@ final class QrView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final primaryColor = Theme.of(context).colorScheme.primary;
+    const qrForegroundColor = Colors.black;
     final qrImg = QrImage(QrCode.fromData(
       data: data,
       errorCorrectLevel: QrErrorCorrectLevel.M,
@@ -34,7 +34,7 @@ final class QrView extends StatelessWidget {
       background: Colors.white,
       shape: PrettyQrSmoothSymbol(
         roundFactor: 1,
-        color: primaryColor,
+        color: qrForegroundColor,
       ),
       image:
           centerImg != null ? PrettyQrDecorationImage(image: centerImg!) : null,
@@ -49,7 +49,7 @@ final class QrView extends StatelessWidget {
           Text(
             tip!,
             style: TextStyle(
-              color: primaryColor,
+              color: qrForegroundColor,
               fontSize: 17,
               fontWeight: FontWeight.w500,
             ),

--- a/lib/src/view/widget/split.dart
+++ b/lib/src/view/widget/split.dart
@@ -386,7 +386,7 @@ class _SplitViewState extends State<SplitView> with SingleTickerProviderStateMix
       data: MultiSplitViewThemeData(
         dividerPainter: DividerPainters.grooved1(
           color: UIs.bgColor.resolve(context),
-          highlightedColor: UIs.primaryColor,
+          highlightedColor: Theme.of(context).colorScheme.primary,
         ),
       ),
       child: multiSplitView,

--- a/lib/src/view/widget/switch_indicator.dart
+++ b/lib/src/view/widget/switch_indicator.dart
@@ -73,7 +73,7 @@ class _SwitchState extends State<SwitchIndicator> with TickerProviderStateMixin 
               child ?? UIs.placeholder,
               ScaleTransition(
                 scale: _showIndicatorAnim,
-                child: _buildIndicator(),
+                child: _buildIndicator(context),
               ),
             ],
           );
@@ -82,7 +82,7 @@ class _SwitchState extends State<SwitchIndicator> with TickerProviderStateMixin 
     );
   }
 
-  Widget _buildIndicator() {
+  Widget _buildIndicator(BuildContext context) {
     final icon = _scrollDirection == null
         ? null
         : Icon(
@@ -94,7 +94,7 @@ class _SwitchState extends State<SwitchIndicator> with TickerProviderStateMixin 
 
     return ClipOval(
       child: ColoredBox(
-        color: UIs.colorSeed,
+        color: Theme.of(context).colorScheme.primary,
         child: Padding(padding: const EdgeInsets.all(_kPadding), child: icon),
       ),
     );


### PR DESCRIPTION
Consistently use `Theme.of(context).colorScheme.primary` to retrieve the theme color, thereby improving code maintainability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了加载指示器、Markdown 文本、二维码视图、分割线和开关指示器等多个组件的主题适配：组件颜色现在更依赖当前主题色（包括对暗/亮主题的动态响应），替代先前的固定配色，提升视觉一致性与主题一致性。二维码符色调整以增强可读性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->