### PR TITLE
fix(ui): add gutter for desktop multi-list scrollbars

### DIFF
--- a/lib/src/view/widget/list.dart
+++ b/lib/src/view/widget/list.dart
@@ -14,6 +14,7 @@ final class MultiList extends StatefulWidget {
 
   /// Number used to divide available width for column sizing.
   final double widthDivider;
+  final double scrollbarGutter;
 
   const MultiList({
     super.key,
@@ -21,6 +22,7 @@ final class MultiList extends StatefulWidget {
     this.outerPadding = kOuterPadding,
     this.widthDivider = 2.2,
     this.betweenPadding = 10,
+    this.scrollbarGutter = 12,
   });
 
   /// Default outer padding.
@@ -81,6 +83,7 @@ final class _MultiListState extends State<MultiList> {
             return SizedBox(
               width: columnWidth,
               child: ListView.builder(
+                padding: EdgeInsets.only(right: widget.scrollbarGutter),
                 itemCount: col.length,
                 itemBuilder: (_, index) => col[index],
               ),

--- a/lib/src/view/widget/list.dart
+++ b/lib/src/view/widget/list.dart
@@ -23,7 +23,7 @@ final class MultiList extends StatefulWidget {
     this.widthDivider = 2.2,
     this.betweenPadding = 10,
     this.scrollbarGutter = 12,
-  });
+  }) : assert(scrollbarGutter >= 0);
 
   /// Default outer padding.
   static const kOuterPadding = EdgeInsets.symmetric(horizontal: 17, vertical: 13);
@@ -83,7 +83,7 @@ final class _MultiListState extends State<MultiList> {
             return SizedBox(
               width: columnWidth,
               child: ListView.builder(
-                padding: EdgeInsets.only(right: widget.scrollbarGutter),
+                padding: EdgeInsetsDirectional.only(end: widget.scrollbarGutter),
                 itemCount: col.length,
                 itemBuilder: (_, index) => col[index],
               ),


### PR DESCRIPTION
## Summary
- add a small right gutter for desktop `MultiList` columns
- prevent content from sitting too close to the scrollbar

## Test plan
- [x] Run on macOS
- [x] Check settings and backup pages
- [x] Verify the desktop layout looks more comfortable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增可配置的滚动条间距（默认 12px），在桌面端为每列保留横向滚动条空间，避免内容被遮挡并改善布局呈现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->