### PR TITLE
Use GitHub releases for app update checks

### DIFF
--- a/lib/src/core/update.dart
+++ b/lib/src/core/update.dart
@@ -7,14 +7,24 @@ abstract final class AppUpdateIface {
 
   static Future<void> doUpdate({
     required BuildContext context,
-    required String url,
+    required String githubReleasesUrl,
     required int build,
+    String? storeUrl,
     bool force = false,
     bool beta = false,
   }) async {
     if (isWeb) return;
 
-    await AppUpdate.fromUrl(url: url, locale: l10n.localeName, build: build);
+    try {
+      await AppUpdate.fromGitHubReleasesUrl(
+        url: githubReleasesUrl,
+        build: build,
+        storeUrl: storeUrl,
+      );
+    } catch (e, s) {
+      Loggers.app.warning('Check update failed', e, s);
+      return;
+    }
 
     final result = AppUpdate.version;
     if (result == null) {

--- a/lib/src/core/utils/platform/base.dart
+++ b/lib/src/core/utils/platform/base.dart
@@ -2,7 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
-import 'package:fl_lib/fl_lib.dart';
+import 'package:fl_lib/src/core/ext/ctx/l10n.dart';
+import 'package:fl_lib/src/core/ext/datetime.dart';
+import 'package:fl_lib/src/core/ext/string.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:logging/logging.dart';

--- a/lib/src/model/update.dart
+++ b/lib/src/model/update.dart
@@ -1,37 +1,46 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
-import 'package:fl_lib/fl_lib.dart';
+import 'package:fl_lib/src/core/dio.dart';
+import 'package:fl_lib/src/core/utils/platform/arch.dart';
+import 'package:fl_lib/src/core/utils/platform/base.dart';
+import 'package:logging/logging.dart';
 
 /// Parse and provide app update metadata from a JSON manifest.
 ///
 /// The manifest supports per-channel (stable/beta), per-OS, and per-arch
 /// overrides for build numbers, changelog, and download URLs.
 abstract final class AppUpdate {
-  static final _arch = CpuArch.current.name;
-  static final _os = Pfs.type.name;
-  static final _osArch = '$_os-$_arch';
-  static var _resKey = '${chan.name}-$_osArch';
-  static var _chanOs = '${chan.name}-$_os';
+  static final _logger = Logger('AppUpdate');
+
+  static String get _arch => CpuArch.current.name;
+  static String get _os => Pfs.type.name;
+  static String get _osArch => '$_os-$_arch';
+  static String get _resKey => '${chan.name}-$_osArch';
+  static String get _chanOs => '${chan.name}-$_os';
 
   static var _chan = AppUpdateChan.stable;
   /// Current update channel.
   static AppUpdateChan get chan => _chan;
   static set chan(AppUpdateChan value) {
-    _updateChanRelated(value);
+    if (value == _chan) return;
+    _chan = value;
     _getAll();
   }
 
   static void _updateChanRelated(AppUpdateChan value) {
     if (value == _chan) return;
     _chan = value;
-    _resKey = '${_chan.name}-$_osArch';
-    _chanOs = '${_chan.name}-$_os';
   }
 
   static var _build = 0;
   static var _data = <String, dynamic>{};
   static var _locale = '';
+  static var _source = _AppUpdateSource.manifest;
+  static var _githubReleases = <Map<String, dynamic>>[];
+  static String? _githubStoreUrl;
+  static Pfs? _githubPlatform;
+  static CpuArch? _githubArch;
 
   static String _rmComment(String raw) {
     return (raw.split('\n')..removeWhere((e) => e.trimLeft().startsWith('//')))
@@ -51,6 +60,7 @@ abstract final class AppUpdate {
     _data = data;
     _locale = locale;
     _build = build;
+    _source = _AppUpdateSource.manifest;
     _getAll();
   }
 
@@ -65,15 +75,71 @@ abstract final class AppUpdate {
     _data = data;
     _locale = locale;
     _build = build;
+    _source = _AppUpdateSource.manifest;
+    _getAll();
+  }
+
+  /// Load and parse releases from the GitHub Releases API.
+  static Future<void> fromGitHubReleasesUrl({
+    required String url,
+    required int build,
+    String? storeUrl,
+  }) async {
+    final resp = await myDio.get(
+      url,
+      options: Options(responseType: ResponseType.plain),
+    );
+    fromGitHubReleasesStr(
+      raw: resp.data.toString(),
+      build: build,
+      storeUrl: storeUrl,
+    );
+  }
+
+  /// Load and parse a raw GitHub Releases API response.
+  static void fromGitHubReleasesStr({
+    required String raw,
+    required int build,
+    String? storeUrl,
+    Pfs? platform,
+    CpuArch? arch,
+  }) {
+    final decoded = json.decode(raw);
+    if (decoded is! List) {
+      throw FormatException('Expected GitHub releases list, got $decoded');
+    }
+    _githubReleases = decoded
+        .whereType<Map<String, dynamic>>()
+        .map(Map<String, dynamic>.from)
+        .toList();
+    _build = build;
+    _source = _AppUpdateSource.github;
+    _githubStoreUrl = storeUrl;
+    _githubPlatform = platform;
+    _githubArch = arch;
     _getAll();
   }
 
   static void _getAll() {
     _changelog = _url = _version = null;
+    if (_source == _AppUpdateSource.github) {
+      _getGitHubAll();
+      return;
+    }
     // Keep this order
     _getChangelog();
     _getVersion();
     _getUrl();
+  }
+
+  static void _getGitHubAll() {
+    final release = _getGitHubRelease();
+    if (release == null) return;
+    final newest = _parseGitHubBuild(release);
+    if (newest == null) return;
+    _version = AppUpdateVer(latest: newest).parse(_build);
+    _changelog = release.body;
+    _url = _getGitHubUrl(release);
   }
 
   static String? _changelog;
@@ -158,7 +224,7 @@ abstract final class AppUpdate {
       try {
         return AppUpdateVer.fromJson(map).parse(_build);
       } catch (e) {
-        Loggers.app.warning('AppUpdateVer.fromJson failed', e);
+        _logger.warning('AppUpdateVer.fromJson failed', e);
       }
       return null;
     }
@@ -213,6 +279,93 @@ abstract final class AppUpdate {
         .replaceAll('{CHAN}', chan.name);
   }
 
+  static _GitHubRelease? _getGitHubRelease() {
+    final stable = _latestGitHubRelease(prerelease: false);
+    if (chan == AppUpdateChan.stable) return stable;
+
+    final beta = _latestGitHubRelease(prerelease: true);
+    if (beta == null) {
+      _updateChanRelated(AppUpdateChan.stable);
+      return stable;
+    }
+    if (stable == null) return beta;
+    if (beta.build >= stable.build) return beta;
+    _updateChanRelated(AppUpdateChan.stable);
+    return stable;
+  }
+
+  static _GitHubRelease? _latestGitHubRelease({required bool prerelease}) {
+    _GitHubRelease? latest;
+    for (final release in _githubReleases) {
+      if (release['draft'] == true) continue;
+      if (release['prerelease'] != prerelease) continue;
+      final parsed = _GitHubRelease.fromJson(release);
+      if (parsed == null) continue;
+      if (latest == null || parsed.build > latest.build) {
+        latest = parsed;
+      }
+    }
+    return latest;
+  }
+
+  static int? _parseGitHubBuild(_GitHubRelease release) => release.build;
+
+  static String? _getGitHubUrl(_GitHubRelease release) {
+    final platform = _githubPlatform ?? Pfs.type;
+    final arch = _githubArch ?? CpuArch.current;
+    final assets = release.assets;
+
+    switch (platform) {
+      case Pfs.android:
+        return _findGitHubAsset(
+          assets,
+          (asset) => asset.name.endsWith('.apk') && asset.hasArch(arch),
+        )?.url;
+      case Pfs.linux:
+        final appImages = assets.where(
+          (asset) => asset.name.endsWith('.AppImage') && asset.hasArch(arch),
+        );
+        return _preferNonLegacy(appImages)?.url;
+      case Pfs.windows:
+        return _findGitHubAsset(
+          assets,
+          (asset) =>
+              asset.name.endsWith('.zip') &&
+              asset.name.contains('windows') &&
+              asset.hasArch(arch),
+        )?.url;
+      case Pfs.macos:
+        return _findGitHubAsset(
+              assets,
+              (asset) => asset.name.endsWith('.dmg'),
+            )?.url ??
+            _githubStoreUrl;
+      case Pfs.ios:
+        return _githubStoreUrl;
+      case Pfs.web || Pfs.fuchsia || Pfs.unknown:
+        return null;
+    }
+  }
+
+  static _GitHubAsset? _findGitHubAsset(
+    Iterable<_GitHubAsset> assets,
+    bool Function(_GitHubAsset asset) test,
+  ) {
+    for (final asset in assets) {
+      if (test(asset)) return asset;
+    }
+    return null;
+  }
+
+  static _GitHubAsset? _preferNonLegacy(Iterable<_GitHubAsset> assets) {
+    _GitHubAsset? legacy;
+    for (final asset in assets) {
+      if (!asset.name.contains('legacy')) return asset;
+      legacy ??= asset;
+    }
+    return legacy;
+  }
+
   // static Map<String, String> _asStrMap(Map<String, dynamic> data) {
   //   final ret = <String, String>{};
   //   for (final key in data.keys) {
@@ -223,6 +376,87 @@ abstract final class AppUpdate {
   //   }
   //   return ret;
   // }
+}
+
+enum _AppUpdateSource {
+  manifest,
+  github,
+}
+
+final class _GitHubRelease {
+  final int build;
+  final String? body;
+  final List<_GitHubAsset> assets;
+
+  const _GitHubRelease({
+    required this.build,
+    required this.body,
+    required this.assets,
+  });
+
+  factory _GitHubRelease._fromJson(Map<String, dynamic> data) {
+    final build = _parseBuild(data['tag_name']) ?? _parseBuild(data['name']);
+    if (build == null) {
+      throw FormatException('GitHub release build not found: $data');
+    }
+
+    final assets = (data['assets'] as List? ?? [])
+        .whereType<Map<String, dynamic>>()
+        .map((asset) => _GitHubAsset.fromJson(Map<String, dynamic>.from(asset)))
+        .nonNulls
+        .toList();
+
+    return _GitHubRelease(
+      build: build,
+      body: data['body'] as String?,
+      assets: assets,
+    );
+  }
+
+  static _GitHubRelease? fromJson(Map<String, dynamic> data) {
+    try {
+      return _GitHubRelease._fromJson(data);
+    } catch (e) {
+      AppUpdate._logger.warning('GitHub release parse failed', e);
+      return null;
+    }
+  }
+
+  static int? _parseBuild(Object? raw) {
+    if (raw == null) return null;
+    final matches = RegExp(r'\d+').allMatches(raw.toString()).toList();
+    if (matches.isEmpty) return null;
+    return int.tryParse(matches.last.group(0)!);
+  }
+}
+
+final class _GitHubAsset {
+  final String name;
+  final String url;
+
+  const _GitHubAsset({
+    required this.name,
+    required this.url,
+  });
+
+  static _GitHubAsset? fromJson(Map<String, dynamic> data) {
+    final name = data['name'];
+    final url = data['browser_download_url'];
+    if (name is! String || url is! String) return null;
+    return _GitHubAsset(name: name, url: url);
+  }
+
+  bool hasArch(CpuArch arch) {
+    final lower = name.toLowerCase();
+    return switch (arch) {
+      CpuArch.amd64 => lower.contains('amd64') || lower.contains('x86_64'),
+      CpuArch.arm64 => lower.contains('arm64') || lower.contains('aarch64'),
+      CpuArch.arm => lower.contains('_arm.') ||
+          lower.contains('_arm_') ||
+          lower.contains('-arm.') ||
+          lower.contains('-arm_'),
+    };
+  }
 }
 
 /// Update channels supported by the app.

--- a/lib/src/model/update.dart
+++ b/lib/src/model/update.dart
@@ -42,6 +42,22 @@ abstract final class AppUpdate {
   static Pfs? _githubPlatform;
   static CpuArch? _githubArch;
 
+  /// Reset mutable state between tests.
+  static void resetForTest() {
+    _chan = AppUpdateChan.stable;
+    _build = 0;
+    _data = <String, dynamic>{};
+    _locale = '';
+    _source = _AppUpdateSource.manifest;
+    _githubReleases = <Map<String, dynamic>>[];
+    _githubStoreUrl = null;
+    _githubPlatform = null;
+    _githubArch = null;
+    _changelog = null;
+    _url = null;
+    _version = null;
+  }
+
   static String _rmComment(String raw) {
     return (raw.split('\n')..removeWhere((e) => e.trimLeft().startsWith('//')))
         .join('\n');
@@ -137,9 +153,11 @@ abstract final class AppUpdate {
     if (release == null) return;
     final newest = _parseGitHubBuild(release);
     if (newest == null) return;
+    final url = _getGitHubUrl(release);
+    if (url == null) return;
+    _url = url;
     _version = AppUpdateVer(latest: newest).parse(_build);
     _changelog = release.body;
-    _url = _getGitHubUrl(release);
   }
 
   static String? _changelog;
@@ -335,10 +353,9 @@ abstract final class AppUpdate {
               asset.hasArch(arch),
         )?.url;
       case Pfs.macos:
-        return _findGitHubAsset(
-              assets,
-              (asset) => asset.name.endsWith('.dmg'),
-            )?.url ??
+        final dmgs = assets.where((asset) => asset.name.endsWith('.dmg'));
+        return _findGitHubAsset(dmgs, (asset) => asset.hasArch(arch))?.url ??
+            _findGitHubAsset(dmgs, (asset) => !asset.hasAnyArch)?.url ??
             _githubStoreUrl;
       case Pfs.ios:
         return _githubStoreUrl;
@@ -457,6 +474,8 @@ final class _GitHubAsset {
           lower.contains('-arm_'),
     };
   }
+
+  bool get hasAnyArch => CpuArch.values.any(hasArch);
 }
 
 /// Update channels supported by the app.

--- a/test/update_test.dart
+++ b/test/update_test.dart
@@ -1,59 +1,244 @@
-import 'dart:io';
+import 'dart:convert';
 
-import 'package:fl_lib/fl_lib.dart';
-import 'package:fl_lib/src/res/l10n.dart';
+import 'package:fl_lib/src/core/utils/platform/arch.dart';
+import 'package:fl_lib/src/core/utils/platform/base.dart';
+import 'package:fl_lib/src/model/update.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('parse update', () async {
-    const build = 1;
-    final raw = await File('test/update.jsonc').readAsString();
-    expect(l10n.localeName, 'en');
-    AppUpdate.fromStr(raw: raw, locale: l10n.localeName, build: build);
-    expect(
-      AppUpdate.changelog,
-      '1. add some features\n2. fix some bugs',
+  setUp(() {
+    AppUpdate.chan = AppUpdateChan.stable;
+  });
+
+  test('github stable release uses release body and platform asset', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.3',
+          body: 'stable body',
+          assets: [
+            _asset('ServerBox_v1.0.3_arm64.apk'),
+          ],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.android,
+      arch: CpuArch.arm64,
     );
-    expect(AppUpdate.version, (3, AppUpdateLevel.recommended));
+
+    expect(AppUpdate.version, (3, AppUpdateLevel.normal));
+    expect(AppUpdate.changelog, 'stable body');
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.3_arm64.apk');
+  });
+
+  test('github stable release ignores drafts and older releases', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.4',
+          draft: true,
+          assets: [_asset('ServerBox_v1.0.4_arm64.apk')],
+        ),
+        _release(
+          tag: 'v1.0.3',
+          assets: [_asset('ServerBox_v1.0.3_arm64.apk')],
+        ),
+        _release(
+          tag: 'v1.0.2',
+          assets: [_asset('ServerBox_v1.0.2_arm64.apk')],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.android,
+      arch: CpuArch.arm64,
+    );
+
+    expect(AppUpdate.version, (3, AppUpdateLevel.normal));
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.3_arm64.apk');
+  });
+
+  test('github beta channel uses newer prerelease', () {
+    AppUpdate.chan = AppUpdateChan.beta;
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.3',
+          prerelease: true,
+          assets: [_asset('ServerBox_v1.0.3_amd64.AppImage')],
+        ),
+        _release(
+          tag: 'v1.0.2',
+          assets: [_asset('ServerBox_v1.0.2_amd64.AppImage')],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.linux,
+      arch: CpuArch.amd64,
+    );
+
+    expect(AppUpdate.version, (3, AppUpdateLevel.normal));
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.3_amd64.AppImage');
+  });
+
+  test('github current build is up to date', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.3',
+          assets: [_asset('ServerBox_v1.0.3_arm64.apk')],
+        ),
+      ]),
+      build: 3,
+      platform: Pfs.android,
+      arch: CpuArch.arm64,
+    );
+
+    expect(AppUpdate.version, (3, AppUpdateLevel.nil));
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.3_arm64.apk');
+  });
+
+  test('github beta channel falls back to newer stable', () {
+    AppUpdate.chan = AppUpdateChan.beta;
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.4',
+          prerelease: true,
+          assets: [_asset('ServerBox_v1.0.4_windows_amd64.zip')],
+        ),
+        _release(
+          tag: 'v1.0.5',
+          assets: [_asset('ServerBox_v1.0.5_windows_amd64.zip')],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.windows,
+      arch: CpuArch.amd64,
+    );
+
+    expect(AppUpdate.chan, AppUpdateChan.stable);
+    expect(AppUpdate.version, (5, AppUpdateLevel.normal));
     expect(
       AppUpdate.url,
-      'https://github.com/lollipopkit/flutter_gpt_box'
-      '/releases/download/v1.0.3/GPTBox_3_amd64.AppImage',
+      'https://download/ServerBox_v1.0.5_windows_amd64.zip',
     );
   });
 
-  test('beta chan', () async {
-    const build = 1;
-    AppUpdate.chan = AppUpdateChan.beta;
-    final raw = await File('test/update.jsonc').readAsString();
-    expect(l10n.localeName, 'en');
-    AppUpdate.fromStr(raw: raw, locale: l10n.localeName, build: build);
-    expect(
-      AppUpdate.changelog,
-      '1. add some features\n2. fix some bugs',
+  test('github linux prefers non legacy AppImage', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.3',
+          assets: [
+            _asset('ServerBox_v1.0.3_legacy_amd64.AppImage'),
+            _asset('ServerBox_v1.0.3_amd64.AppImage'),
+          ],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.linux,
+      arch: CpuArch.amd64,
     );
-    expect(AppUpdate.version, (3, AppUpdateLevel.forced));
-    expect(
-      AppUpdate.url,
-      'https://cdn.lolli.tech/gptbox/GPTBox_3_amd64.AppImage',
-    );
+
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.3_amd64.AppImage');
   });
 
-  test('beta use stable', () async {
-    const build = 2;
-    AppUpdate.chan = AppUpdateChan.beta;
-    final raw = await File('test/update2.jsonc').readAsString();
-    expect(l10n.localeName, 'en');
-    AppUpdate.fromStr(raw: raw, locale: l10n.localeName, build: build);
-    expect(
-      AppUpdate.changelog,
-      '1. add some features',
+  test('github macos uses dmg and falls back to store url', () {
+    final raw = _githubRaw([
+      _release(
+        tag: 'v1.0.3',
+        assets: [_asset('ServerBox-1.0.3.dmg')],
+      ),
+    ]);
+
+    AppUpdate.fromGitHubReleasesStr(
+      raw: raw,
+      build: 1,
+      storeUrl: 'https://apps.apple.com/app/id1586449703',
+      platform: Pfs.macos,
+      arch: CpuArch.arm64,
+    );
+    expect(AppUpdate.url, 'https://download/ServerBox-1.0.3.dmg');
+
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(tag: 'v1.0.3', assets: const []),
+      ]),
+      build: 1,
+      storeUrl: 'https://apps.apple.com/app/id1586449703',
+      platform: Pfs.macos,
+      arch: CpuArch.arm64,
+    );
+    expect(AppUpdate.url, 'https://apps.apple.com/app/id1586449703');
+  });
+
+  test('github ios always uses store url', () {
+    final raw = _githubRaw([
+      _release(
+        tag: 'v1.0.3',
+        assets: [_asset('ServerBox-1.0.3.dmg')],
+      ),
+    ]);
+
+    AppUpdate.fromGitHubReleasesStr(
+      raw: raw,
+      build: 1,
+      storeUrl: 'https://apps.apple.com/app/id1586449703',
+      platform: Pfs.ios,
+      arch: CpuArch.arm64,
+    );
+    expect(AppUpdate.url, 'https://apps.apple.com/app/id1586449703');
+  });
+
+  test('github invalid tag yields no update', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(tag: 'invalid', assets: [_asset('ServerBox.zip')]),
+      ]),
+      build: 1,
+      platform: Pfs.windows,
+      arch: CpuArch.amd64,
+    );
+    expect(AppUpdate.version, isNull);
+    expect(AppUpdate.url, isNull);
+  });
+
+  test('github missing platform asset keeps version but has no update url', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(tag: 'v1.0.3', assets: [_asset('ServerBox.zip')]),
+      ]),
+      build: 1,
+      platform: Pfs.windows,
+      arch: CpuArch.amd64,
     );
     expect(AppUpdate.version, (3, AppUpdateLevel.normal));
-    expect(
-      AppUpdate.url,
-      'https://github.com/lollipopkit/flutter_gpt_box'
-      '/releases/download/v1.0.3/GPTBox_3_amd64.AppImage',
-    );
+    expect(AppUpdate.url, isNull);
   });
+}
+
+String _githubRaw(List<Map<String, dynamic>> releases) => json.encode(releases);
+
+Map<String, dynamic> _release({
+  required String tag,
+  bool prerelease = false,
+  bool draft = false,
+  String? body,
+  List<Map<String, dynamic>> assets = const [],
+}) {
+  return {
+    'tag_name': tag,
+    'name': tag,
+    'draft': draft,
+    'prerelease': prerelease,
+    'body': body,
+    'assets': assets,
+  };
+}
+
+Map<String, dynamic> _asset(String name) {
+  return {
+    'name': name,
+    'browser_download_url': 'https://download/$name',
+  };
 }

--- a/test/update_test.dart
+++ b/test/update_test.dart
@@ -7,7 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   setUp(() {
-    AppUpdate.chan = AppUpdateChan.stable;
+    AppUpdate.resetForTest();
+  });
+
+  tearDown(() {
+    AppUpdate.resetForTest();
   });
 
   test('github stable release uses release body and platform asset', () {
@@ -172,6 +176,27 @@ void main() {
     expect(AppUpdate.url, 'https://apps.apple.com/app/id1586449703');
   });
 
+  test('github macos prefers current architecture dmg over generic dmg', () {
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.3',
+          assets: [
+            _asset('App-1.0.3-x86_64.dmg'),
+            _asset('App-1.0.3.dmg'),
+            _asset('App-1.0.3-arm64.dmg'),
+          ],
+        ),
+      ]),
+      build: 1,
+      storeUrl: 'https://apps.apple.com/app/id1586449703',
+      platform: Pfs.macos,
+      arch: CpuArch.arm64,
+    );
+
+    expect(AppUpdate.url, 'https://download/App-1.0.3-arm64.dmg');
+  });
+
   test('github ios always uses store url', () {
     final raw = _githubRaw([
       _release(
@@ -203,7 +228,7 @@ void main() {
     expect(AppUpdate.url, isNull);
   });
 
-  test('github missing platform asset keeps version but has no update url', () {
+  test('github missing platform asset exposes no update', () {
     AppUpdate.fromGitHubReleasesStr(
       raw: _githubRaw([
         _release(tag: 'v1.0.3', assets: [_asset('ServerBox.zip')]),
@@ -212,7 +237,7 @@ void main() {
       platform: Pfs.windows,
       arch: CpuArch.amd64,
     );
-    expect(AppUpdate.version, (3, AppUpdateLevel.normal));
+    expect(AppUpdate.version, isNull);
     expect(AppUpdate.url, isNull);
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 更新检查现在支持从 GitHub Releases 获取更新信息；可选提供商店链接作为补充下载来源。
  * 会按不同平台/架构更精准地选择匹配的发布资产（含对 beta/稳定版的优先级与回退策略）。
* **Bug 修复**
  * 检查更新失败时会捕获异常并记录日志，避免影响应用正常使用。
  * 优化发布版本筛选与解析逻辑，减少因无效发布或不匹配资产导致的错误更新提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->