### PR TITLE
fix: 关闭系统导航栏对比度遮罩，让底部菜单背景延伸到系统导航栏

### DIFF
--- a/lib/src/core/utils/ui.dart
+++ b/lib/src/core/utils/ui.dart
@@ -35,7 +35,10 @@ abstract final class SystemUIs {
     if (isAndroid) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
       SystemChrome.setSystemUIOverlayStyle(
-        const SystemUiOverlayStyle(systemNavigationBarColor: Colors.transparent, systemNavigationBarContrastEnforced: true),
+        const SystemUiOverlayStyle(
+          systemNavigationBarColor: Colors.transparent,
+          systemNavigationBarContrastEnforced: false,
+        ),
       );
     }
   }


### PR DESCRIPTION
### 修复

系统导航栏是白色，跟底部菜单栏背景色不一致，导致UI很突兀，整体没有统一感。

关闭系统导航栏对比度遮罩，让底部菜单背景延伸到系统导航栏

### 修复对比
<div>
  <img width="230" style="display: inline-block;" alt="48abbd05a6d49f4ecee59c584b192fbb" src="https://github.com/user-attachments/assets/e4171490-77c1-4c1c-a8fc-f0030464385b" />
  <img width="230" style="display: inline-block;" alt="f00e4c5b0ee6447ea976ded864352cf3" src="https://github.com/user-attachments/assets/a591aee4-c162-4b37-9766-e6f658a27892" />
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android transparent navigation bar appearance by disabling system contrast enforcement, helping maintain the intended visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->