### PR TITLE
fix(update): offer the newest release this platform can install

### DIFF
--- a/lib/src/core/update.dart
+++ b/lib/src/core/update.dart
@@ -48,7 +48,15 @@ abstract final class AppUpdateIface {
 
     final fileUrl = AppUpdate.url;
     if (fileUrl == null) {
-      Loggers.app.warning('Update file not available: $fileUrl');
+      // A newer build exists, but no release carries an asset for this
+      // platform — an arch the project does not ship, in practice. Staying
+      // quiet is deliberate: there is nothing the user could act on, and this
+      // state does not clear on its own.
+      // TODO: [newestBuild] is set, so the settings page reads "click to
+      // update" and the tap then does nothing. It needs a third state for
+      // "newer version exists, no build for this platform", which needs a
+      // string in libL10n.
+      Loggers.app.warning('No update asset for ${Pfs.type} at build $newest');
       return;
     }
 

--- a/lib/src/core/update.dart
+++ b/lib/src/core/update.dart
@@ -37,8 +37,13 @@ abstract final class AppUpdateIface {
     }
 
     final newest = result.$1;
+    final fileUrl = AppUpdate.url;
 
-    newestBuild.value = newest;
+    // Only a build that can be installed from here, or the one already
+    // running, belongs on screen. The settings page reads "click to update"
+    // off [newestBuild], so publishing a version with no asset for this
+    // platform would put a tap there with nothing behind it.
+    if (fileUrl != null || newest <= build) newestBuild.value = newest;
 
     if (!force && newest <= build) {
       Loggers.app.info('Update ignored: $build >= $newest');
@@ -46,16 +51,11 @@ abstract final class AppUpdateIface {
     }
     Loggers.app.info('Update available: $newest');
 
-    final fileUrl = AppUpdate.url;
     if (fileUrl == null) {
       // A newer build exists, but no release carries an asset for this
-      // platform — an arch the project does not ship, in practice. Staying
-      // quiet is deliberate: there is nothing the user could act on, and this
-      // state does not clear on its own.
-      // TODO: [newestBuild] is set, so the settings page reads "click to
-      // update" and the tap then does nothing. It needs a third state for
-      // "newer version exists, no build for this platform", which needs a
-      // string in libL10n.
+      // platform — an arch the project does not ship, in practice. Silence is
+      // deliberate: there is nothing the user could act on, and the state does
+      // not clear on its own, so a notice would repeat on every launch.
       Loggers.app.warning('No update asset for ${Pfs.type} at build $newest');
       return;
     }

--- a/lib/src/core/update.dart
+++ b/lib/src/core/update.dart
@@ -43,7 +43,13 @@ abstract final class AppUpdateIface {
     // running, belongs on screen. The settings page reads "click to update"
     // off [newestBuild], so publishing a version with no asset for this
     // platform would put a tap there with nothing behind it.
-    if (fileUrl != null || newest <= build) newestBuild.value = newest;
+    //
+    // Cleared rather than left alone in that case: this notifier outlives the
+    // check, so an earlier one that did find an asset would otherwise keep
+    // offering that build after it stopped being on offer. A null [fileUrl]
+    // means no release carries an asset for this platform at all, so there is
+    // nothing left to point at.
+    newestBuild.value = fileUrl != null || newest <= build ? newest : null;
 
     if (!force && newest <= build) {
       Loggers.app.info('Update ignored: $build >= $newest');

--- a/lib/src/model/update.dart
+++ b/lib/src/model/update.dart
@@ -157,16 +157,24 @@ abstract final class AppUpdate {
     if (Pfs.type != Pfs.ios) return null;
     final url = appStoreLookupUrl(storeUrl);
     if (url == null) return null;
+    // [myDio] sets no timeout and treats every status as success, so this has
+    // to bound itself: a store that does not answer must delay the update
+    // check by seconds, not hold it open. Timing out reads as "unknown",
+    // which trusts the tag.
+    final cancel = CancelToken();
     try {
-      // [myDio] sets no timeout and treats every status as success, so this
-      // has to bound itself: a store that does not answer must delay the
-      // update check by seconds, not hold it open. Timing out reads as
-      // "unknown", which trusts the tag.
       final resp = await myDio
-          .get(url, options: Options(responseType: ResponseType.plain))
+          .get(
+            url,
+            options: Options(responseType: ResponseType.plain),
+            cancelToken: cancel,
+          )
           .timeout(const Duration(seconds: 5));
       return parseAppStoreBuild(resp.data.toString());
     } catch (e) {
+      // [Future.timeout] only stops the waiting. Without this the request
+      // itself stays open, holding a socket for a result nobody reads.
+      cancel.cancel('App Store lookup abandoned');
       _logger.warning('App Store lookup failed', e);
       return null;
     }
@@ -224,7 +232,16 @@ abstract final class AppUpdate {
     // build still in review, leaves the rest on an earlier one. Offering that
     // earlier one beats offering nothing — the alternative is that one
     // partial release mutes the update check until the next full one.
+    //
+    // The channel downgrade in [_getGitHubRelease] is meant to be decided by
+    // what the user can install, so the installable pass is allowed to make
+    // it. It must not stick when that pass comes back empty: the fallback
+    // below and the release notes both read [chan], and a beta user with no
+    // installable asset anywhere would otherwise be reported the newest
+    // stable and left on a channel they never chose.
+    final chanBefore = _chan;
     final installable = _getGitHubRelease(installable: true);
+    if (installable == null) _chan = chanBefore;
 
     // Nothing installable anywhere: still report the newest release, so the
     // settings page names the real version instead of "unknown". [url] stays
@@ -441,6 +458,26 @@ abstract final class AppUpdate {
     return stable;
   }
 
+  /// [_storeBuild], but only when it is a build number in the same space as
+  /// the release tags.
+  ///
+  /// [_parseBuild] reads the last run of digits, which is the build under this
+  /// project's `v1.0.<build>` tags but not under marketing versioning: an App
+  /// Store version of `1.4.0` reads as build 0 and `1.4.1` as build 1, and
+  /// either would reject every release and mute iOS updates permanently.
+  ///
+  /// An iOS build can only have been installed from the store, so the store
+  /// does not serve something older than what is running. A value below the
+  /// installed build means the two are not the same numbering. Answering null
+  /// then is deliberate — unknown trusts the tag, so a wrong guess here costs
+  /// one prompt too many rather than silence.
+  static int? get _comparableStoreBuild {
+    final storeBuild = _storeBuild;
+    if (storeBuild == null) return null;
+    if (storeBuild <= 0 || storeBuild < _build) return null;
+    return storeBuild;
+  }
+
   static _GitHubRelease? _latestGitHubRelease({
     required bool prerelease,
     bool installable = false,
@@ -491,7 +528,8 @@ abstract final class AppUpdate {
         // every launch, with no way to act on it. An unknown store build
         // means the lookup failed, and one failed lookup must not mute
         // updates for good — so that case still trusts the tag.
-        if (_storeBuild != null && release.build > _storeBuild!) return null;
+        final storeBuild = _comparableStoreBuild;
+        if (storeBuild != null && release.build > storeBuild) return null;
         return _githubStoreUrl;
       case Pfs.web || Pfs.fuchsia || Pfs.unknown:
         return null;

--- a/lib/src/model/update.dart
+++ b/lib/src/model/update.dart
@@ -41,6 +41,7 @@ abstract final class AppUpdate {
   static String? _githubStoreUrl;
   static Pfs? _githubPlatform;
   static CpuArch? _githubArch;
+  static int? _storeBuild;
 
   /// Reset mutable state between tests.
   static void resetForTest() {
@@ -53,6 +54,7 @@ abstract final class AppUpdate {
     _githubStoreUrl = null;
     _githubPlatform = null;
     _githubArch = null;
+    _storeBuild = null;
     _changelog = null;
     _releaseNotes = const [];
     _versionName = null;
@@ -103,22 +105,82 @@ abstract final class AppUpdate {
     required int build,
     String? storeUrl,
   }) async {
-    final resp = await myDio.get(
+    // Both requests go out at once: the store lookup only says anything on
+    // iOS, and must not add a round trip to the check on every other platform.
+    final releasesReq = myDio.get(
       url,
       options: Options(responseType: ResponseType.plain),
     );
+    final storeReq = _fetchAppStoreBuild(storeUrl);
+    final resp = await releasesReq;
     fromGitHubReleasesStr(
       raw: resp.data.toString(),
       build: build,
       storeUrl: storeUrl,
+      storeBuild: await storeReq,
     );
   }
 
+  /// The iTunes lookup URL for an App Store page [storeUrl], or null when it
+  /// carries no app id.
+  static String? appStoreLookupUrl(String? storeUrl) {
+    if (storeUrl == null) return null;
+    final id = RegExp(r'/id(\d+)').firstMatch(storeUrl)?.group(1);
+    if (id == null) return null;
+    return 'https://itunes.apple.com/lookup?id=$id';
+  }
+
+  /// The build number in an iTunes lookup response, or null when the response
+  /// names no version — an app id that matches nothing answers with an empty
+  /// `results` list rather than an error.
+  static int? parseAppStoreBuild(String raw) {
+    try {
+      final data = json.decode(raw);
+      if (data is! Map) return null;
+      final results = data['results'];
+      if (results is! List || results.isEmpty) return null;
+      final first = results.first;
+      if (first is! Map) return null;
+      return _parseBuild(first['version']);
+    } catch (e) {
+      _logger.warning('App Store lookup parse failed', e);
+      return null;
+    }
+  }
+
+  /// What the App Store currently serves, or null when it could not be read.
+  ///
+  /// Only asked on iOS: everywhere else the release assets say what is
+  /// installable, and macOS only reaches the store URL when a release carries
+  /// no dmg at all.
+  static Future<int?> _fetchAppStoreBuild(String? storeUrl) async {
+    if (Pfs.type != Pfs.ios) return null;
+    final url = appStoreLookupUrl(storeUrl);
+    if (url == null) return null;
+    try {
+      // [myDio] sets no timeout and treats every status as success, so this
+      // has to bound itself: a store that does not answer must delay the
+      // update check by seconds, not hold it open. Timing out reads as
+      // "unknown", which trusts the tag.
+      final resp = await myDio
+          .get(url, options: Options(responseType: ResponseType.plain))
+          .timeout(const Duration(seconds: 5));
+      return parseAppStoreBuild(resp.data.toString());
+    } catch (e) {
+      _logger.warning('App Store lookup failed', e);
+      return null;
+    }
+  }
+
   /// Load and parse a raw GitHub Releases API response.
+  ///
+  /// [storeBuild] is what the App Store serves, when known; see
+  /// [_fetchAppStoreBuild].
   static void fromGitHubReleasesStr({
     required String raw,
     required int build,
     String? storeUrl,
+    int? storeBuild,
     Pfs? platform,
     CpuArch? arch,
   }) {
@@ -139,6 +201,7 @@ abstract final class AppUpdate {
     _githubStoreUrl = storeUrl;
     _githubPlatform = platform;
     _githubArch = arch;
+    _storeBuild = storeBuild;
     _getAll();
   }
 
@@ -156,14 +219,23 @@ abstract final class AppUpdate {
   }
 
   static void _getGitHubAll() {
-    final release = _getGitHubRelease();
-    if (release == null) return;
-    final url = _getGitHubUrl(release);
-    if (url == null) return;
-    _url = url;
-    _version = AppUpdateVer(latest: release.build).parse(_build);
-    _versionName = release.tag;
-    _releaseNotes = _getGitHubReleaseNotes(release.build);
+    // The newest release this platform can install, which is not always the
+    // newest release: a version published for some platforms only, or an iOS
+    // build still in review, leaves the rest on an earlier one. Offering that
+    // earlier one beats offering nothing — the alternative is that one
+    // partial release mutes the update check until the next full one.
+    final installable = _getGitHubRelease(installable: true);
+
+    // Nothing installable anywhere: still report the newest release, so the
+    // settings page names the real version instead of "unknown". [url] stays
+    // null and no update is offered, since there is nothing to offer.
+    final target = installable ?? _getGitHubRelease();
+    if (target == null) return;
+
+    _url = installable == null ? null : _getGitHubUrl(installable);
+    _version = AppUpdateVer(latest: target.build).parse(_build);
+    _versionName = target.tag;
+    _releaseNotes = _getGitHubReleaseNotes(target.build);
     _changelog = switch (_releaseNotes.length) {
       0 => null,
       1 => _releaseNotes.first.body,
@@ -345,11 +417,20 @@ abstract final class AppUpdate {
         .replaceAll('{CHAN}', chan.name);
   }
 
-  static _GitHubRelease? _getGitHubRelease() {
-    final stable = _latestGitHubRelease(prerelease: false);
+  /// The release to offer, or with [installable] the newest one that resolves
+  /// to a download for this platform.
+  ///
+  /// [_getGitHubAll] asks for the installable one first, so the channel
+  /// downgrade below is decided by what the user can actually get: a beta user
+  /// whose newest prerelease is the only one carrying their platform's asset
+  /// stays on beta rather than being dropped to an older stable.
+  static _GitHubRelease? _getGitHubRelease({bool installable = false}) {
+    final stable =
+        _latestGitHubRelease(prerelease: false, installable: installable);
     if (chan == AppUpdateChan.stable) return stable;
 
-    final beta = _latestGitHubRelease(prerelease: true);
+    final beta =
+        _latestGitHubRelease(prerelease: true, installable: installable);
     if (beta == null) {
       _updateChanRelated(AppUpdateChan.stable);
       return stable;
@@ -360,13 +441,16 @@ abstract final class AppUpdate {
     return stable;
   }
 
-  static _GitHubRelease? _latestGitHubRelease({required bool prerelease}) {
+  static _GitHubRelease? _latestGitHubRelease({
+    required bool prerelease,
+    bool installable = false,
+  }) {
     _GitHubRelease? latest;
     for (final release in _githubReleases) {
       if (release.prerelease != prerelease) continue;
-      if (latest == null || release.build > latest.build) {
-        latest = release;
-      }
+      if (latest != null && release.build <= latest.build) continue;
+      if (installable && _getGitHubUrl(release) == null) continue;
+      latest = release;
     }
     return latest;
   }
@@ -401,6 +485,13 @@ abstract final class AppUpdate {
             _findGitHubAsset(dmgs, (asset) => !asset.hasAnyArch)?.url ??
             _githubStoreUrl;
       case Pfs.ios:
+        // A tag exists the moment it is pushed; the App Store build behind it
+        // can still be in review for days. Offering it would send the user to
+        // a store page that serves the build they are already running, on
+        // every launch, with no way to act on it. An unknown store build
+        // means the lookup failed, and one failed lookup must not mute
+        // updates for good — so that case still trusts the tag.
+        if (_storeBuild != null && release.build > _storeBuild!) return null;
         return _githubStoreUrl;
       case Pfs.web || Pfs.fuchsia || Pfs.unknown:
         return null;
@@ -529,13 +620,15 @@ final class _GitHubRelease {
       return null;
     }
   }
+}
 
-  static int? _parseBuild(Object? raw) {
-    if (raw == null) return null;
-    final matches = RegExp(r'\d+').allMatches(raw.toString()).toList();
-    if (matches.isEmpty) return null;
-    return int.tryParse(matches.last.group(0)!);
-  }
+/// The build number in a version string: the last run of digits, so a GitHub
+/// tag `v1.0.1491` and an App Store version `1.0.1491` both yield 1491.
+int? _parseBuild(Object? raw) {
+  if (raw == null) return null;
+  final matches = RegExp(r'\d+').allMatches(raw.toString()).toList();
+  if (matches.isEmpty) return null;
+  return int.tryParse(matches.last.group(0)!);
 }
 
 final class _GitHubAsset {

--- a/test/update_iface_test.dart
+++ b/test/update_iface_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:fl_lib/src/core/dio.dart';
+import 'package:fl_lib/src/core/update.dart';
+import 'package:fl_lib/src/model/update.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late HttpClientAdapter original;
+  late _StubAdapter stub;
+
+  setUp(() {
+    original = myDio.httpClientAdapter;
+    stub = _StubAdapter();
+    myDio.httpClientAdapter = stub;
+    AppUpdate.resetForTest();
+    AppUpdateIface.newestBuild.value = null;
+  });
+
+  tearDown(() {
+    myDio.httpClientAdapter = original;
+    AppUpdate.resetForTest();
+    AppUpdateIface.newestBuild.value = null;
+  });
+
+  /// Runs a check against [releases].
+  ///
+  /// Through [WidgetTester.runAsync] because the response arrives on the real
+  /// event loop, which the fake-async zone a `testWidgets` body runs in never
+  /// pumps. Every case here returns before [BuildContext] is read, so no
+  /// overlay or toast host is needed.
+  Future<void> check(
+    WidgetTester tester,
+    BuildContext ctx, {
+    required List<Map<String, dynamic>> releases,
+    required int build,
+  }) async {
+    stub.body = json.encode(releases);
+    await tester.runAsync(() => AppUpdateIface.doUpdate(
+          context: ctx,
+          githubReleasesUrl: 'https://example.invalid/releases',
+          build: build,
+        ));
+  }
+
+  Future<BuildContext> pumpCtx(WidgetTester tester) async {
+    late BuildContext ctx;
+    await tester.pumpWidget(MaterialApp(home: Builder(builder: (c) {
+      ctx = c;
+      return const SizedBox();
+    })));
+    return ctx;
+  }
+
+  testWidgets('a check with no asset clears what an earlier one published',
+      (tester) async {
+    final ctx = await pumpCtx(tester);
+
+    await check(
+      tester,
+      ctx,
+      releases: [_release(tag: 'v1.0.200', assets: _hostAssets('1.0.200'))],
+      build: 200,
+    );
+    expect(AppUpdateIface.newestBuild.value, 200,
+        reason: 'an installable build is published');
+
+    // Now no release carries an asset for this platform. Leaving 200 in place
+    // would keep the settings page naming a build that is no longer on offer,
+    // and its tap would do nothing.
+    await check(
+      tester,
+      ctx,
+      releases: [
+        _release(tag: 'v1.0.300'),
+        _release(tag: 'v1.0.200'),
+      ],
+      build: 200,
+    );
+    expect(AppUpdateIface.newestBuild.value, isNull);
+  });
+
+  testWidgets('the running build is published even with no asset',
+      (tester) async {
+    final ctx = await pumpCtx(tester);
+
+    // Nothing to download, but the newest release is what is already running.
+    // "Up to date" is the truth, and there is no tap to mislead.
+    await check(
+      tester,
+      ctx,
+      releases: [_release(tag: 'v1.0.100')],
+      build: 100,
+    );
+    expect(AppUpdateIface.newestBuild.value, 100);
+  });
+}
+
+/// Assets named so one release matches whichever host the suite runs on.
+///
+/// `arm64_amd64` satisfies [CpuArch.arm64] and [CpuArch.amd64] alike, and the
+/// dmg carries no arch at all, which is what the macOS branch falls back to.
+List<Map<String, dynamic>> _hostAssets(String version) => [
+      _asset('App-$version.dmg'),
+      _asset('App_v${version}_arm64_amd64.apk'),
+      _asset('App_v${version}_arm64_amd64.AppImage'),
+      _asset('App_v${version}_windows_arm64_amd64.zip'),
+    ];
+
+final class _StubAdapter implements HttpClientAdapter {
+  String body = '[]';
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(body, 200, headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _release({
+  required String tag,
+  List<Map<String, dynamic>> assets = const [],
+}) {
+  return {
+    'tag_name': tag,
+    'name': tag,
+    'draft': false,
+    'prerelease': false,
+    'body': 'notes',
+    'assets': assets,
+  };
+}
+
+Map<String, dynamic> _asset(String name) {
+  return {
+    'name': name,
+    'browser_download_url': 'https://download/$name',
+  };
+}

--- a/test/update_test.dart
+++ b/test/update_test.dart
@@ -390,7 +390,10 @@ void main() {
     expect(AppUpdate.url, isNull);
   });
 
-  test('github missing platform asset exposes no update', () {
+  test('github missing platform asset still names the newest version', () {
+    // No release has a Windows asset, so there is nothing to install — but the
+    // version is known and the settings page should say so rather than
+    // "unknown".
     AppUpdate.fromGitHubReleasesStr(
       raw: _githubRaw([
         _release(tag: 'v1.0.3', assets: [_asset('ServerBox.zip')]),
@@ -399,8 +402,254 @@ void main() {
       platform: Pfs.windows,
       arch: CpuArch.amd64,
     );
-    expect(AppUpdate.version, isNull);
+    expect(AppUpdate.version, (3, AppUpdateLevel.normal));
+    expect(AppUpdate.versionName, 'v1.0.3');
     expect(AppUpdate.url, isNull);
+  });
+
+  group('release published for some platforms only', () {
+    // The shape this was written for: v1.0.1491 shipped a dmg, an AppImage, a
+    // Windows zip and an ipa, and no apk at all.
+    String raw() => _githubRaw([
+          _release(
+            tag: 'v1.0.1491',
+            body: 'ninety one',
+            assets: [
+              _asset('ServerBox-1.0.1491.dmg'),
+              _asset('ServerBox_v1.0.1491_amd64.AppImage'),
+              _asset('ServerBox_v1.0.1491_windows_amd64.zip'),
+            ],
+          ),
+          _release(
+            tag: 'v1.0.1480',
+            body: 'eighty',
+            assets: [
+              _asset('ServerBox-1.0.1480.dmg'),
+              _asset('ServerBox_v1.0.1480_amd64.apk'),
+              _asset('ServerBox_v1.0.1480_arm64.apk'),
+              _asset('ServerBox_v1.0.1480_arm.apk'),
+              _asset('ServerBox_v1.0.1480_windows_amd64.zip'),
+            ],
+          ),
+        ]);
+
+    test('offers the newest release that has an asset for this platform', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1466,
+        platform: Pfs.android,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1480, AppUpdateLevel.normal));
+      expect(AppUpdate.versionName, 'v1.0.1480');
+      expect(AppUpdate.url, 'https://download/ServerBox_v1.0.1480_arm64.apk');
+      // The notes stop at what is being offered: 1491 is not on the way in.
+      expect(AppUpdate.releaseNotes.map((e) => e.title).toList(), ['v1.0.1480']);
+    });
+
+    test('is up to date on the newest release carrying its asset', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1480,
+        platform: Pfs.android,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1480, AppUpdateLevel.nil));
+      expect(AppUpdate.releaseNotes, isEmpty);
+    });
+
+    test('platforms in that release are unaffected', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1466,
+        platform: Pfs.windows,
+        arch: CpuArch.amd64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(
+        AppUpdate.url,
+        'https://download/ServerBox_v1.0.1491_windows_amd64.zip',
+      );
+      expect(
+        AppUpdate.releaseNotes.map((e) => e.title).toList(),
+        ['v1.0.1491', 'v1.0.1480'],
+      );
+    });
+
+    test('an arch with no asset in any release falls back to the newest', () {
+      // Linux arm64: every AppImage is amd64, so nothing is installable.
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1466,
+        platform: Pfs.linux,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(AppUpdate.url, isNull);
+    });
+  });
+
+  group('ios store build', () {
+    String raw() => _githubRaw([
+          _release(tag: 'v1.0.1491', body: 'ninety one'),
+          _release(tag: 'v1.0.1480', body: 'eighty'),
+        ]);
+
+    const storeUrl = 'https://apps.apple.com/app/id1586449703';
+
+    test('a tag still in review is not offered', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1480,
+        storeUrl: storeUrl,
+        storeBuild: 1480,
+        platform: Pfs.ios,
+        arch: CpuArch.arm64,
+      );
+
+      // 1491 exists on GitHub but the store still serves 1480, which is what
+      // is running: no update, rather than a prompt that cannot be acted on.
+      expect(AppUpdate.version, (1480, AppUpdateLevel.nil));
+      expect(AppUpdate.versionName, 'v1.0.1480');
+      expect(AppUpdate.url, storeUrl);
+    });
+
+    test('a released build is offered once the store serves it', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1480,
+        storeUrl: storeUrl,
+        storeBuild: 1491,
+        platform: Pfs.ios,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(AppUpdate.url, storeUrl);
+      expect(AppUpdate.releaseNotes.map((e) => e.title).toList(), ['v1.0.1491']);
+    });
+
+    test('a store ahead of the tag still offers the newest tag', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1466,
+        storeUrl: storeUrl,
+        storeBuild: 1500,
+        platform: Pfs.ios,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+    });
+
+    test('an unknown store build trusts the tag', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1480,
+        storeUrl: storeUrl,
+        platform: Pfs.ios,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(AppUpdate.url, storeUrl);
+    });
+
+    test('a store behind every tag reports the newest and offers nothing', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: raw(),
+        build: 1466,
+        storeUrl: storeUrl,
+        storeBuild: 1466,
+        platform: Pfs.ios,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(AppUpdate.url, isNull);
+    });
+
+    test('the store build does not constrain macos', () {
+      AppUpdate.fromGitHubReleasesStr(
+        raw: _githubRaw([
+          _release(tag: 'v1.0.1491', assets: [_asset('ServerBox-1.0.1491.dmg')]),
+        ]),
+        build: 1480,
+        storeUrl: storeUrl,
+        storeBuild: 1480,
+        platform: Pfs.macos,
+        arch: CpuArch.arm64,
+      );
+
+      expect(AppUpdate.version, (1491, AppUpdateLevel.normal));
+      expect(AppUpdate.url, 'https://download/ServerBox-1.0.1491.dmg');
+    });
+  });
+
+  group('app store lookup', () {
+    test('lookup url is derived from the store page url', () {
+      expect(
+        AppUpdate.appStoreLookupUrl('https://apps.apple.com/app/id1586449703'),
+        'https://itunes.apple.com/lookup?id=1586449703',
+      );
+      expect(
+        AppUpdate.appStoreLookupUrl(
+          'https://apps.apple.com/us/app/serverbox/id1586449703?mt=8',
+        ),
+        'https://itunes.apple.com/lookup?id=1586449703',
+      );
+      expect(AppUpdate.appStoreLookupUrl(null), isNull);
+      expect(AppUpdate.appStoreLookupUrl('https://example.com/app'), isNull);
+    });
+
+    test('build is read from the version string', () {
+      expect(
+        AppUpdate.parseAppStoreBuild('{"resultCount":1,'
+            '"results":[{"version":"1.0.1480"}]}'),
+        1480,
+      );
+    });
+
+    test('a response naming no app yields null', () {
+      expect(
+        AppUpdate.parseAppStoreBuild('{"resultCount":0,"results":[]}'),
+        isNull,
+      );
+      expect(AppUpdate.parseAppStoreBuild('{"results":[{}]}'), isNull);
+      expect(AppUpdate.parseAppStoreBuild('not json'), isNull);
+      expect(AppUpdate.parseAppStoreBuild('[]'), isNull);
+    });
+  });
+
+  test('github beta stays on a prerelease that has this platform asset', () {
+    // The stable is newer but shipped no apk; downgrading the channel here
+    // would hand the beta user an older build than the one waiting for them.
+    AppUpdate.chan = AppUpdateChan.beta;
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(tag: 'v1.0.6', assets: [_asset('ServerBox-1.0.6.dmg')]),
+        _release(
+          tag: 'v1.0.5',
+          prerelease: true,
+          assets: [_asset('ServerBox_v1.0.5_arm64.apk')],
+        ),
+        _release(
+          tag: 'v1.0.4',
+          assets: [_asset('ServerBox_v1.0.4_arm64.apk')],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.android,
+      arch: CpuArch.arm64,
+    );
+
+    expect(AppUpdate.chan, AppUpdateChan.beta);
+    expect(AppUpdate.version, (5, AppUpdateLevel.normal));
+    expect(AppUpdate.url, 'https://download/ServerBox_v1.0.5_arm64.apk');
   });
 }
 

--- a/test/update_test.dart
+++ b/test/update_test.dart
@@ -573,6 +573,27 @@ void main() {
       expect(AppUpdate.url, isNull);
     });
 
+    test('a marketing version scheme is ignored rather than obeyed', () {
+      // `1.4.0` reads as build 0 under [_parseBuild], and `1.4.1` as build 1.
+      // Either would reject every release and mute iOS updates for good, so a
+      // store build below every known release is treated as unknown.
+      for (final storeBuild in [0, 1]) {
+        AppUpdate.resetForTest();
+        AppUpdate.fromGitHubReleasesStr(
+          raw: raw(),
+          build: 1480,
+          storeUrl: storeUrl,
+          storeBuild: storeBuild,
+          platform: Pfs.ios,
+          arch: CpuArch.arm64,
+        );
+
+        expect(AppUpdate.version, (1491, AppUpdateLevel.normal),
+            reason: 'storeBuild $storeBuild');
+        expect(AppUpdate.url, storeUrl, reason: 'storeBuild $storeBuild');
+      }
+    });
+
     test('the store build does not constrain macos', () {
       AppUpdate.fromGitHubReleasesStr(
         raw: _githubRaw([
@@ -650,6 +671,40 @@ void main() {
     expect(AppUpdate.chan, AppUpdateChan.beta);
     expect(AppUpdate.version, (5, AppUpdateLevel.normal));
     expect(AppUpdate.url, 'https://download/ServerBox_v1.0.5_arm64.apk');
+  });
+
+  test('github beta keeps its channel when nothing is installable', () {
+    // The installable pass finds no prerelease and no stable, and its channel
+    // downgrade must not survive: reporting the newest stable to a beta user,
+    // and leaving them on stable, would both be wrong.
+    AppUpdate.chan = AppUpdateChan.beta;
+    AppUpdate.fromGitHubReleasesStr(
+      raw: _githubRaw([
+        _release(
+          tag: 'v1.0.5',
+          body: 'five beta',
+          prerelease: true,
+          assets: [_asset('ServerBox-1.0.5.dmg')],
+        ),
+        _release(
+          tag: 'v1.0.4',
+          body: 'four',
+          assets: [_asset('ServerBox-1.0.4.dmg')],
+        ),
+      ]),
+      build: 1,
+      platform: Pfs.android,
+      arch: CpuArch.arm64,
+    );
+
+    expect(AppUpdate.chan, AppUpdateChan.beta);
+    expect(AppUpdate.version, (5, AppUpdateLevel.normal));
+    expect(AppUpdate.versionName, 'v1.0.5');
+    expect(AppUpdate.url, isNull);
+    expect(
+      AppUpdate.releaseNotes.map((e) => e.title).toList(),
+      ['v1.0.5', 'v1.0.4'],
+    );
   });
 }
 


### PR DESCRIPTION
Two ways the GitHub-backed update check reported nothing, or the wrong thing. Both were found against live data on `lollipopkit/flutter_server_box`.

## A release published for some platforms only muted the check for the rest

`_getGitHubAll` took the newest release, asked it for a download URL, and returned early when there was none. A version shipping no apk therefore left Android with no update at all — `version` and `url` both null, settings showing "unknown" — including the earlier releases that did carry one.

It now selects the newest release that resolves to an asset for this platform. When no release does (an arch the project never ships, e.g. Linux arm64), `AppUpdate.version` still reports the newest release so the information is available to a caller, but `AppUpdateIface` keeps it out of the UI: publishing it would leave the settings page reading "click to update" with nothing behind the tap. That case is silent and logged.

Asking for the installable release *first* also means the beta channel downgrade is decided by what the user can actually get. The downgrade is reverted when that pass comes back empty — `_chan` is static, so otherwise a beta user with no installable asset anywhere was reported the newest stable, had prereleases dropped from their notes, and was left on stable for the rest of the process.

## iOS prompted for a build the App Store was not serving yet

The build number came from the GitHub tag, while what an iOS user can install comes from the App Store, which can be days behind in review. The result was a prompt on every launch whose button led to a store page still serving the build already installed, with no way to act on it and no state that cleared on its own.

The check now reads the store's version from the iTunes lookup API and does not offer a tag the store has not caught up to. The request is issued alongside the releases request, bounded by a 5s timeout and cancelled on failure, since `myDio` sets no timeout and treats every status as success. A lookup that fails or times out reads as unknown and still trusts the tag — one failed request must not mute updates for good.

`_parseBuild` reads the last run of digits, which is the build under `v1.0.<build>` tags but not under marketing versioning: `1.4.0` reads as build 0 and `1.4.1` as build 1, either of which would reject every release and mute iOS updates permanently. An iOS build can only have come from the store, so a store build below the installed one is treated as a different numbering, i.e. unknown.

## Verification

Against the real releases list and the real iTunes lookup (App Store on 1.0.1466, newest stable tag 1480, 1491 a prerelease shipping no apk):

| | before | after |
|---|---|---|
| iOS, installed 1466 | prompts 1480, store still serves 1466 | `(1466, nil)`, no prompt |
| beta + Android arm64 | `version=null`, silently dead | 1480 + arm64 apk |
| Linux/Windows/macOS amd64 | correct | unchanged |
| Linux arm64 | `version=null` | `version` reports 1480, UI unchanged and silent |

`test/update_test.dart` goes from 17 to 34 cases, covering both scenarios, the channel interaction, the marketing-version scheme, and the lookup URL/response parsing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS App Store build checks to prevent updates when a newer GitHub release is unavailable through the App Store.
  * Improved update selection across platforms, architectures, stable releases, and beta channels.
  * Version information remains visible even when no compatible download is available.

* **Bug Fixes**
  * Cleared stale update availability when newer releases lack compatible assets.
  * Improved App Store build lookup, parsing, validation, and timeout cancellation.
  * Preserved the selected update channel when no compatible release asset is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->