### PR TITLE
refactor(store): rename Store to KvStore

### DIFF
--- a/lib/src/core/store/hive.dart
+++ b/lib/src/core/store/hive.dart
@@ -2,9 +2,9 @@ part of 'iface.dart';
 
 /// The store of Hive.
 ///
-/// It implements [Store].
-class HiveStore extends Store {
-  /// The internal hive box for this [Store].
+/// It implements [KvStore].
+class HiveStore extends KvStore {
+  /// The internal hive box for this [KvStore].
   ///
   /// Not `final`: [init] may run a second time on the same instance after
   /// `Hive.close()`, which is how an app recovers from box files it turned out

--- a/lib/src/core/store/iface.dart
+++ b/lib/src/core/store/iface.dart
@@ -26,7 +26,7 @@ typedef StoreFromObj<T extends Object> = T? Function(Object? val);
 /// {@macro store_from_to}
 typedef StoreToObj<T extends Object> = Object? Function(T? value);
 
-/// The interface of any [Store].
+/// The interface of any [KvStore].
 ///
 /// The provider of the store can be `shared_preferences`, `hive`, `sqflite`, etc.
 ///
@@ -35,7 +35,7 @@ typedef StoreToObj<T extends Object> = Object? Function(T? value);
 ///
 /// It's designed that only one timestamp for all the data in one store.
 /// {@endtemplate}
-sealed class Store {
+sealed class KvStore {
   /// Serializes changes that read, replace, or restore [lastUpdateTs].
   ///
   /// The map is persisted as one value, so two asynchronous writers cannot
@@ -60,7 +60,7 @@ sealed class Store {
   /// Name of the store
   final String name;
 
-  Store({
+  KvStore({
     required this.name,
     this.updateLastUpdateTsOnSet = StoreDefaults.defaultUpdateLastUpdateTs,
     this.updateLastUpdateTsOnRemove = StoreDefaults.defaultUpdateLastUpdateTs,
@@ -279,7 +279,7 @@ sealed class Store {
   }
 }
 
-/// The interface of a single Property in any [Store].
+/// The interface of a single Property in any [KvStore].
 ///
 /// Such as the `user_token` in `shared_preferences`, `user` in `hive`, etc.
 abstract class StoreProp<T extends Object> {
@@ -304,7 +304,7 @@ abstract class StoreProp<T extends Object> {
   /// - [fromObj] & [toObj], you can refer to [StoreFromObj] & [StoreToObj].
   /// - [store] is the store of the property.
   /// - [updateLastUpdateTsOnSetProp] is whether to update the last update timestamp
-  ///of this [Store] when setting a value for this property.
+  ///of this [KvStore] when setting a value for this property.
   /// {@endtemplate}
   const StoreProp(
     this.key, {
@@ -313,8 +313,8 @@ abstract class StoreProp<T extends Object> {
     this.updateLastUpdateTsOnSetProp = StoreDefaults.defaultUpdateLastUpdateTs,
   });
 
-  /// It's [Store].
-  Store get store;
+  /// It's [KvStore].
+  KvStore get store;
 
   /// Get the value of the key.
   T? get() => store.get(key, fromObj: fromObj);
@@ -355,7 +355,7 @@ abstract class StoreProp<T extends Object> {
   bool get updateLastUpdateTsOnSet => store.updateLastUpdateTsOnSet && updateLastUpdateTsOnSetProp;
 }
 
-/// The interface of a single Property in any [Store] which has a default value.
+/// The interface of a single Property in any [KvStore] which has a default value.
 ///
 /// Such as the `user_token` in `shared_preferences`, `user` in `hive`, etc.
 abstract class StorePropDefault<T extends Object> extends StoreProp<T> {
@@ -389,7 +389,7 @@ abstract class StorePropDefault<T extends Object> extends StoreProp<T> {
 }
 
 /// The keys used internally in the store.
-extension StoreDefaults on Store {
+extension StoreDefaults on KvStore {
   /// {@template store_defaults_prefix_key}
   /// The prefix of the internal keys.
   ///

--- a/lib/src/core/store/mock.dart
+++ b/lib/src/core/store/mock.dart
@@ -2,9 +2,9 @@ part of 'iface.dart';
 
 // ignore_for_file: unnecessary_this
 
-/// A mock implementation of [Store] that keeps data in memory.
+/// A mock implementation of [KvStore] that keeps data in memory.
 /// Persistence operations complete asynchronously, matching production stores.
-class MockStore extends Store {
+class MockStore extends KvStore {
   final Map<String, Object> _mem = {};
 
   MockStore({

--- a/lib/src/core/store/pref.dart
+++ b/lib/src/core/store/pref.dart
@@ -53,7 +53,7 @@ typedef PrefStoreKeyListener = void Function(String key);
 /// {@template PrefStore.init}
 /// `MUST` call [init] before using any pref stores.
 /// {@endtemplate}
-final class PrefStore extends Store {
+final class PrefStore extends KvStore {
   /// The prefix of SharedPreferences.
   ///
   /// Defaults to `''`.

--- a/lib/src/core/store/sqlite.dart
+++ b/lib/src/core/store/sqlite.dart
@@ -213,12 +213,12 @@ CREATE TABLE IF NOT EXISTS kv (
 
 /// The store of SQLite.
 ///
-/// It implements [Store]. Values are JSON, so what comes back out of [get] is
+/// It implements [KvStore]. Values are JSON, so what comes back out of [get] is
 /// what `jsonDecode` produces — a `Map`, a `List` or a primitive — and the
 /// `fromObj` hook every caller already passes is what turns it back into a
 /// model. That is the same path [HiveStore] used for anything without a
 /// `TypeAdapter`, now the only path.
-class SqliteStore extends Store {
+class SqliteStore extends KvStore {
   /// Constructor.
   SqliteStore(
     String name, {

--- a/lib/src/core/sync/iface.dart
+++ b/lib/src/core/sync/iface.dart
@@ -46,7 +46,7 @@ abstract class Mergeable {
   /// Returns true if any changes were made to the store.
   static Future<bool> mergeStore({
     required Map<String, Object?> backupData,
-    required Store store,
+    required KvStore store,
     required bool force,
   }) async {
     bool hasChanges = false;

--- a/lib/src/provider/app.g.dart
+++ b/lib/src/provider/app.g.dart
@@ -46,7 +46,7 @@ abstract class _$AppStates extends $Notifier<AppState> {
   AppState build();
   @$mustCallSuper
   @override
-  WhenComplete runBuild() {
+  void runBuild() {
     final ref = this.ref as $Ref<AppState, AppState>;
     final element =
         ref.element
@@ -56,6 +56,6 @@ abstract class _$AppStates extends $Notifier<AppState> {
               Object?,
               Object?
             >;
-    return element.handleCreate(ref, build);
+    element.handleCreate(ref, build);
   }
 }


### PR DESCRIPTION
## What

`sealed class Store` becomes `sealed class KvStore`. The four subclasses
(`SqliteStore`, `HiveStore`, `PrefStore`, `MockStore`), `extension
StoreDefaults on KvStore`, and `StoreProp.store` follow. Nothing else changes.

## Why

The interface is key-value: `get(key)`, `set(key, value)`, `remove(key)`,
`keys()`. Calling it `Store` made that a coincidence of the API rather than a
statement about what it is, and left no name for storage that is not
key-addressed.

That matters now, because server_box is moving its entities out of a JSON blob
in a value column and into real tables. With both shapes present, `extends
Store` reads as "the store base class" and hands whoever writes the next one a
`set(key, value)` — which only fits by putting the JSON blob back, the thing
the move exists to undo. `KvStore` states its own constraint, so an entity
store visibly does not belong to it.

`StoreProp.store` becoming `KvStore get store` is the same point: a property is
addressed by key, and that is now a fact rather than an accident.

## The second commit

`lib/src/provider/app.g.dart` was checked in with `runBuild` returning
`WhenComplete`, a type the riverpod that resolves here does not have. So
`flutter analyze` fails and every widget test fails to *compile* — on `main`,
before this branch. Regenerating is two lines and it is what makes CI able to
say anything about the first commit.

## Verified

- `flutter analyze lib test` — clean (was 1 error on main)
- `flutter test` — 253 passing (was 23 files failing to load on main)
- server_box builds and passes its 1036 tests against this branch

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the public storage interface to `KvStore`.
  * Updated built-in storage implementations and synchronization APIs to use the renamed interface.
  * Updated related documentation and type references for consistency.
  * Simplified application build handling so it no longer exposes a completion result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->